### PR TITLE
Add exception for barman user home

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 DIST := $(DIR)/dist
 DIST_FOR_TEST := $(DIR)/tests/docker
+VERSION ?= $(shell cat $(DIR)/VERSION | head -n 1)
 
 build:
 	sed -E 's/version:.*/version: "$(VERSION)"/g' $(DIR)/galaxy.template.yml > $(DIR)/galaxy.yml

--- a/roles/init_dbserver/tasks/setup_locale.yml
+++ b/roles/init_dbserver/tasks/setup_locale.yml
@@ -9,5 +9,5 @@
 
 - name: Set pg_locale to default locale
   ansible.builtin.set_fact:
-    pg_locale: "{{ ansible_env.LANG | default('C') }}"
+    pg_locale: "{{ 'en_US.utf8' if ansible_os_family == 'RedHat' else 'C.UTF-8' if ansible_os_family == 'Debian' }}"
   when: locale_stat.stdout_lines | length < 1

--- a/roles/setup_barman/defaults/main.yml
+++ b/roles/setup_barman/defaults/main.yml
@@ -1,11 +1,13 @@
 ---
 pg_instance_name: main
-use_hostname: false
 
 pg_owner: postgres
 pg_port: 5432
 
+barman_user: "barman"
+barman_group: "barman"
 barman_pg_user: "barman"
+barman_configuration_files_directory: "/etc/barman.d"
 barman: true
 barman_server_private_ip: ""
 
@@ -14,4 +16,5 @@ pg_group: postgres
 pg_port: 5432
 
 etc_hosts_lists: []
+use_hostname: false
 update_etc_file: true

--- a/roles/setup_barman/vars/main.yml
+++ b/roles/setup_barman/vars/main.yml
@@ -3,9 +3,7 @@ pg_major_version: "{{ pg_version | int }}"
 
 barman_cli_package: "barman-cli-3.2.0-1"
 
-barman_user: "barman"
 barman_home: "/var/lib/barman"
-
 # SSH listening port
 ssh_port: 22
 

--- a/roles/setup_barmanserver/defaults/main.yml
+++ b/roles/setup_barmanserver/defaults/main.yml
@@ -3,12 +3,11 @@ barman_user: "barman"
 barman_group: "barman"
 barman_configuration_file: "/etc/barman.conf"
 barman_configuration_files_directory: "/etc/barman.d"
-barman_home: "/var/lib/barman"
 barman_lock_directory: "/var/run/barman"
 barman_log_file: "/var/log/barman/barman.log"
 barman_log_level: "INFO"
 barman_compression: "gzip"
 
 etc_hosts_lists: []
-use_hostname: true
+use_hostname: false
 update_etc_file: true

--- a/roles/setup_barmanserver/tasks/create_user.yml
+++ b/roles/setup_barmanserver/tasks/create_user.yml
@@ -15,6 +15,16 @@
     home: "{{ barman_home }}"
   become: true
 
+- name: Check barman user home directory
+  ansible.builtin.stat:
+    path: "{{ barman_home }}"
+  register: barman_home_stat
+
+- name: Verify barman home directory permissions
+  ansible.builtin.fail:
+    msg: Barman Syste user do not have permission to access the home directory. Check user barman_home parameter.
+  when: barman_home_stat.stat.pw_name != barman_user
+
 - name: Check if getenforce is installed
   ansible.builtin.shell: command -v getenforce > /dev/null 2>&1
   register: getenforce_installed

--- a/roles/setup_barmanserver/vars/main.yml
+++ b/roles/setup_barmanserver/vars/main.yml
@@ -5,6 +5,7 @@ python2_barman_package: "python2-barman-3.2.0-1"
 barman_cli_package: "barman-cli-3.2.0-1"
 
 barman_default_home: "/var/lib/barman"
+barman_home: "/var/lib/barman"
 
 supported_os:
   - CentOS7


### PR DESCRIPTION
# Changed
- Added fail that barman user home cannot have barman user privileges
- Set archive_command not to include hostname if hostname is not enabled
- Added default variables in setup_barman
- Disabled "barman_home" user defined parameter