### PR TITLE
Modified checking manage_pgpool2 pcp_users state

### DIFF
--- a/roles/manage_pgpool2/tasks/pcp_add_user.yml
+++ b/roles/manage_pgpool2/tasks/pcp_add_user.yml
@@ -7,7 +7,7 @@
   become_user: "{{ pg_owner }}"
   when:
     - pcp_user|length > 0
-    - pcp_user.state is not defined or user_item.state == 'present'
+    - pcp_user.state is not defined or pcp_user.state == 'present'
   register: pcp_password_out
 
 - name: Update pcp.conf
@@ -18,4 +18,4 @@
   become_user: "{{ pg_owner }}"
   when:
     - pcp_user|length > 0
-    - pcp_user.state is not defined or user_item.state == 'present'
+    - pcp_user.state is not defined or pcp_user.state == 'present'

--- a/tests/cases/manage_pgpool2/vars.json
+++ b/tests/cases/manage_pgpool2/vars.json
@@ -22,7 +22,8 @@
   "pcp_users": [
     {
       "name": "test",
-      "pass": "password"
+      "pass": "password",
+      "state": "present"
     }
   ]
 }


### PR DESCRIPTION
## Classification
- [ ] Feature
- [ ] Hotfix
- [X] Patch
- [ ] Others

## Content
- Modified referencing other variables when checking the status of pcp_users
- Added manage_pgpool2 test variable "pcp_users"'s state 

## Reproduction Steps
- cd tests/ python3 test-runner.py -k manage_pgpool2
