### PR TITLE
Disabled switch barman_backup_method

### DIFF
--- a/roles/setup_barman/README.md
+++ b/roles/setup_barman/README.md
@@ -68,6 +68,9 @@ barman_server_private_ip: 10.0.0.123
 
 ### `barman_backup_method`
 
+After setup_barman role is executed, changing backup method may result in loss of the backup copy.
+So barman_backup_method manages the current backup method in the ~/.backup_method file of each server and prevents method conversion.
+
 Backup method. Can be:
 
 - `postgres` for backups based on `pg_basebackup` using Streaming

--- a/roles/setup_barman/tasks/archive_barman.yml
+++ b/roles/setup_barman/tasks/archive_barman.yml
@@ -1,0 +1,74 @@
+---
+- name: Get Barman server informations
+  set_fact:
+    _barman_server_info: "{{ lookup('tmax_opensql.postgres.barman_server', wantlist=True) }}"
+
+- name: Fail if barman server informations are not found
+  fail:
+    msg: "Unable to find barman server informations"
+  when:
+    - _barman_server_info|length == 0
+
+- name: Set _barman_server_inventory_hostname
+  set_fact:
+    _barman_server_inventory_hostname: "{{ _barman_server_info[0].inventory_hostname }}"
+
+- name: Ensure timeline ID
+  community.postgresql.postgresql_query:
+    query: >-
+      SELECT SUBSTRING(redo_wal_file, 1, 16) AS timeline_id FROM pg_control_checkpoint();
+    port: "{{ pg_port }}"
+    db: "{{ pg_database }}"
+    login_user: "{{ pg_owner }}"
+    login_unix_socket: "{{ pg_unix_socket_directories[0] }}"
+  no_log: "{{ disable_logging }}"
+  become: true
+  become_user: "{{ pg_owner }}"
+  register: _timeline_id
+
+- name: Set timeline ID
+  set_fact:
+    _timeline_id : "{{ _timeline_id.query_result[0].timeline_id }}"
+
+- name: Create wals directory
+  file:
+    path: "{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/wals/{{ _timeline_id }}"
+    state: directory
+    owner: "barman"
+    group: "barman"
+    mode: 0700
+  become: true
+
+- name: Copy streaming directory
+  copy:
+    src: "{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/streaming/"
+    dest: "{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/wals/{{ _timeline_id }}/"
+    remote_src: true
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+  failed_when: false
+
+- name: Copy incoming directory
+  copy:
+    src: "{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/incoming/"
+    dest: "{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/wals/{{ _timeline_id }}/"
+    remote_src: true
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+  failed_when: false
+
+- name: Delete streaming directory when method is rsync
+  file:
+    path: "{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/streaming"
+    state: absent
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+  when: barman_backup_method == 'rsync'
+
+- name: Delete incoming directory when method is postgres
+  file:
+    path: "{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/incoming"
+    state: absent
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+  when: barman_backup_method == 'postgres'
+
+- name: Reset local variables
+  set_fact:
+    _timeline_id: null

--- a/roles/setup_barman/tasks/check_backup_method.yml
+++ b/roles/setup_barman/tasks/check_backup_method.yml
@@ -1,0 +1,64 @@
+---
+- name: Get Barman server informations
+  set_fact:
+    _barman_server_info: "{{ lookup('tmax_opensql.postgres.barman_server', wantlist=True) }}"
+
+- name: Fail if barman server informations are not found
+  fail:
+    msg: "Unable to find barman server informations"
+  when:
+    - _barman_server_info|length == 0
+
+- name: Set _barman_server_inventory_hostname
+  set_fact:
+    _barman_server_inventory_hostname: "{{ _barman_server_info[0].inventory_hostname }}"
+
+- name: Create backup_method file
+  file:
+    path: "{{ barman_home }}/.backup_method"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: '0644'
+    state: "touch"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+
+- name: Wait for create backup_method file
+  wait_for:
+    path: "{{ barman_home }}/.backup_method"
+    state: present
+    msg: "Timeout to find file {{ barman_home }}/.backup_method"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+
+- name: Read backup_method from file
+  ansible.builtin.shell: >-
+    set -o pipefail && grep '^{{ inventory_hostname }}-{{ pg_instance_name }}=' {{ barman_home }}/.backup_method | cut -d'=' -f2
+  args:
+    executable: /bin/bash
+  register: _backup_method
+  become_user: "{{ barman_user }}"
+  failed_when: false
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+
+- name: Set opposite backup method
+  set_fact:
+    _opposite_backup_method: "{{ 'postgres' if barman_backup_method == 'rsync' else 'rsync' if barman_backup_method == 'postgres' }}"
+
+- name: Check barman_backup_method exists
+  fail:
+    msg: "Backup_method cannot be switched."
+  when:
+    - _backup_method.stdout == _opposite_backup_method
+
+- name: Add backup_method line
+  ansible.builtin.lineinfile:
+    path: "{{ barman_home }}/.backup_method"
+    line: '{{ inventory_hostname }}-{{ pg_instance_name }}={{ barman_backup_method }}'
+    regexp: '^{{ inventory_hostname }}-{{ pg_instance_name }}='
+    state: present
+  become_user: "{{ barman_user }}"
+  delegate_to: "{{ _barman_server_inventory_hostname }}"
+
+- name: Reset _backup_method
+  set_fact:
+    _opposite_backup_method: ""
+    _backup_method: ""

--- a/roles/setup_barman/tasks/configure_pg_backup.yml
+++ b/roles/setup_barman/tasks/configure_pg_backup.yml
@@ -45,7 +45,7 @@
     tasks_from: manage_slots
   vars:
     pg_slots:
-      - name: barman
+      - name: barman_{{ inventory_hostname }}_{{ pg_instance_name }}
         slot_type: physical
   no_log: "{{ disable_logging }}"
   when: barman_backup_method == 'postgres'

--- a/roles/setup_barman/tasks/configure_pg_backup.yml
+++ b/roles/setup_barman/tasks/configure_pg_backup.yml
@@ -50,6 +50,13 @@
   no_log: "{{ disable_logging }}"
   when: barman_backup_method == 'postgres'
 
+- name: Set archive command variable
+  set_fact:
+    barman_archive_command: >-
+          rsync -a -e
+          "ssh -p {{ ssh_port }}"
+          %p {{ barman_user }}@{{ _barman_host }}:{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/incoming/%f
+
 - name: Ensure WAL archiving is configured
   include_role:
     name: manage_dbserver
@@ -61,10 +68,7 @@
       # Note: barman-wal-archive does not allow using a different SSH port than
       # the default one.
       - name: archive_command
-        value: >-
-          rsync -a -e
-          "ssh -p {{ ssh_port }}"
-          %p {{ barman_user }}@{{ _barman_host }}:{{ barman_home }}/{{ inventory_hostname }}-{{ pg_instance_name }}/incoming/%f
+        value: "{{ barman_archive_command }}"
   no_log: "{{ disable_logging }}"
   when: barman_backup_method == 'rsync'
 

--- a/roles/setup_barman/tasks/setup_barman.yml
+++ b/roles/setup_barman/tasks/setup_barman.yml
@@ -41,6 +41,9 @@
     - use_hostname|bool
     - update_etc_file|bool
 
+- name: Ensure backup_method
+  include_tasks: check_backup_method.yml
+
 - name: Include the package installation tasks
   include_role:
     name: setup_barmanserver
@@ -66,6 +69,9 @@
 
 - name: Include the SSH keys exchange tasks
   include_tasks: exchange_ssh_keys.yml
+
+- name: Include the archive barman backup files
+  include_tasks: archive_barman.yml
 
 - name: Include the barman configuration tasks
   include_tasks: configure_barman.yml

--- a/roles/setup_barman/templates/barman.postgres.template
+++ b/roles/setup_barman/templates/barman.postgres.template
@@ -5,7 +5,7 @@ conninfo = host={{ pg_host }} user={{ barman_pg_user }} dbname=postgres port={{ 
 streaming_conninfo = host={{ pg_host  }}  user={{ barman_pg_user }} port={{ pg_port }}
 backup_method = postgres
 streaming_archiver = on
-slot_name = barman
+slot_name = barman_{{ inventory_hostname }}_{{ pg_instance_name }}
 backup_options = concurrent_backup
 immediate_checkpoint = true
 recovery_options = get-wal

--- a/roles/setup_barmanserver/tasks/create_directories.yml
+++ b/roles/setup_barmanserver/tasks/create_directories.yml
@@ -17,6 +17,22 @@
     mode: 0750
   become: true
 
+- name: Check barman.conf file directory
+  stat:
+    path: "{{ barman_configuration_file | dirname }}"
+  register: _barman_conf_directory
+
+- name: Enusre barman.conf file directory {{ barman_configuration_file | dirname }} exists
+  file:
+    path: "{{ barman_configuration_file | dirname }}"
+    state: directory
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    mode: 0750
+  become: true
+  when:
+    - not _barman_conf_directory.stat.exists
+
 - name: Ensure configuration files directory {{ barman_configuration_files_directory }} exists
   file:
     path: "{{ barman_configuration_files_directory }}"

--- a/roles/setup_barmanserver/tasks/generate_configuration.yml
+++ b/roles/setup_barmanserver/tasks/generate_configuration.yml
@@ -1,4 +1,17 @@
 ---
+- name: Check if we have symlink for default config file location
+  stat:
+    path: "{{ barman_home }}/.barman.conf"
+  register: barman_conf
+
+- name: Ensure barman config file is deleted if barman_configuration_file is not default
+  file:
+    path: "{{ barman_home }}/.barman.conf"
+    state: absent
+  when:
+    - barman_conf.stat.exists
+  become: true
+
 - name: Build configuration file {{ barman_configuration_file }}
   template:
     src: "./templates/barman.conf.template"
@@ -6,4 +19,16 @@
     owner: "{{ barman_user }}"
     group: "{{ barman_group }}"
     mode: 0600
+  become: true
+
+- name: Create symlink for default barman.conf
+  file:
+    src: "{{ barman_configuration_file }}"
+    dest: "{{ barman_home }}/.barman.conf"
+    owner: "{{ barman_user }}"
+    group: "{{ barman_group }}"
+    state: link
+  when:
+    - barman_configuration_file != '/etc/barman.conf'
+    - barman_configuration_file != "{{ barman_home }}/.barman.conf"
   become: true


### PR DESCRIPTION
## Classification
- [ ] Feature
- [ ] Hotfix
- [X] Patch
- [ ] Others

## Content
- Changed the name of the slot used when barman's backup_method is postgres.
- slot name set barman_<inventory hostname>_<pg_instance_name>.
- Created a symbolic link to barman.conf in barman_home when path is not default.
- Created barman_configuration_file's directory.
- Added archive to wals directory before configure barman
- Disable barman_backup_method switch

## Reproduction Steps
- N/A
