### PR TITLE
Added pgpool_pg_port, pgpool_pg_check password variable

### DIFF
--- a/roles/setup_pgpool2/README.md
+++ b/roles/setup_pgpool2/README.md
@@ -97,6 +97,16 @@ Example:
 pgpool2_port: 5433
 ```
 
+### `pgpool2_pg_port`
+
+PostgreSQL(backend) TCP port to connect to from pgpool. Default: `5432`.
+
+Example:
+
+```yaml
+pgpool2_port: 5434
+```
+
 ## Dependencies
 
 This role does not have any dependencies, but packages repositories should have

--- a/roles/setup_pgpool2/defaults/main.yml
+++ b/roles/setup_pgpool2/defaults/main.yml
@@ -12,6 +12,8 @@ pgpool2_ssl: true
 
 # Default configuration values
 pgpool2_port: 9999
+pgpool2_pg_port: 5432
+pgpool_pg_check_password: ""
 
 # Disable logging
 disable_logging: false

--- a/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_configure_backends.yml
@@ -12,7 +12,7 @@
         },
         {
           'key': 'backend_port'+ ansible_loop.index0 | string,
-          'value': pg_port,
+          'value': pgpool2_pg_port,
           'state': 'present',
           'quoted': false
         },

--- a/roles/setup_pgpool2/tasks/setup_pgpool2.yml
+++ b/roles/setup_pgpool2/tasks/setup_pgpool2.yml
@@ -153,6 +153,12 @@
   vars:
     pgpool2_backends: "{{ _pgpool2_backends }}"
 
+- name: Set password PostgreSQL Check user
+  set_fact:
+    pgpool2_health_check_password: "{{ pgpool_pg_check_password }}"
+    pgpool2_sr_check_password: "{{ pgpool_pg_check_password }}"
+  when: pgpool_pg_check_password|length > 0
+
 - name: Include the pgpool2_setup_sr_mode
   include_tasks: pgpool2_setup_sr_mode.yml
   when:


### PR DESCRIPTION
## Classification
- [ ] Feature
- [ ] Hotfix
- [X] Patch
- [ ] Others

## Content
- Added port var to use when connecting pgpool and PostgreSQL(pgpool_pg_port)
- Added password var to use check PostgreSQL state (pgpool_pg_check_password)

## Reproduction Steps
- N/A
