### PR TITLE
Set up PostgreSQL OS user and group

### DIFF
--- a/roles/init_dbserver/README.md
+++ b/roles/init_dbserver/README.md
@@ -83,6 +83,24 @@ Example:
 ```yaml
 pg_local_wal_archive_dir: "/var/lib/pgsql/14/archive"
 ```
+### `pg_owner`
+
+Using this parameters user can set the OS user that controls PostgreSQL.
+
+Example:
+
+```yaml
+pg_owner: "postgres"
+```
+### `pg_group`
+
+Using this parameters user can set groups of OS users that control PostgreSQL.
+
+Example:
+
+```yaml
+pg_group: "postgres"
+```
 ### pg_owner_id
 
 Using this parameters user can change the uid of postgresql's systemuser.

--- a/roles/manage_dbserver/defaults/main.yml
+++ b/roles/manage_dbserver/defaults/main.yml
@@ -19,6 +19,8 @@ pg_data: "{{ pg_user_home + '/' + pg_major_version + '/data' if ansible_os_famil
      pg_user_home + '/' + pg_major_version  + '/' + pg_instance_name if ansible_os_family == 'Debian' }}"
 
 pg_port: "5432"
+pg_log: "/var/log/postgres"
+pg_wal: "{{ pg_data }}/pg_wal"
 pg_owner: "postgres"
 pg_group: "postgres"
 

--- a/roles/manage_dbserver/vars/PG_Debian.yml
+++ b/roles/manage_dbserver/vars/PG_Debian.yml
@@ -3,12 +3,26 @@ pg_user_home: "/var/lib/postgresql"
 pg_instance_name: "main"
 shell_profile_content: |
   # PostgreSQL shell environment
+  export PGHOME={{ pg_user_home }}
+  export PGLIB=/usr/pgsql-{{ pg_major_version }}/lib
   export PGDATA={{ pg_data }}
   export PGDATABASE=postgres
   export PGUSER={{ pg_owner }}
   export PGPORT={{ pg_port }}
   export PGLOCALEDIR=/usr/lib/postgresql/{{ pg_major_version }}/share/locale
   export PGHOST={{ pg_unix_socket_directories[0] }}
+  export PATH=$PATH:{{ pg_bin_path }}
+
+  #opensql-PostgreSQL ALIAS
+  alias pginst="cd $PGINST"
+  alias pglib="cd $PGLIB"
+  alias pghome="cd $PGHOME"
+  alias pgdata="cd $PGDATA"
+  alias pglog="cd {{ pg_log }}"
+  alias pgwal="cd {{ pg_wal }}"
+  alias pgconf="vi $PGDATA/postgresql.conf"
+  alias pghba="vi $PGDATA/pg_hba.conf"
+
 pg_bin_path: "/usr/lib/postgresql/{{ pg_major_version }}/bin"
 pg_default_data: "/var/lib/postgresql/{{ pg_major_version }}/{{ pg_instance_name }}"
 

--- a/roles/manage_dbserver/vars/PG_RedHat.yml
+++ b/roles/manage_dbserver/vars/PG_RedHat.yml
@@ -2,12 +2,27 @@
 pg_user_home: "/var/lib/pgsql"
 shell_profile_content: |
   # PostgreSQL shell environment
+  export PGHOME={{ pg_user_home }}
+  export PGLIB=/usr/pgsql-{{ pg_major_version }}/lib
+  export PGINST=/usr/pgsql-{{ pg_major_version }}
   export PGDATA={{ pg_data }}
   export PGDATABASE=postgres
-  export PGUSER=postgres
+  export PGUSER={{ pg_owner }}
   export PGPORT={{ pg_port }}
   export PGLOCALEDIR=/usr/pgsql-{{ pg_major_version }}/share/locale
   export PGHOST={{ pg_unix_socket_directories[0] }}
+  export PATH=$PATH:{{ pg_bin_path }}
+
+  #opensql-PostgreSQL ALIAS
+  alias pginst="cd $PGINST"
+  alias pglib="cd $PGLIB"
+  alias pghome="cd $PGHOME"
+  alias pgdata="cd $PGDATA"
+  alias pglog="cd {{ pg_log }}"
+  alias pgwal="cd {{ pg_wal }}"
+  alias pgconf="vi $PGDATA/postgresql.conf"
+  alias pghba="vi $PGDATA/pg_hba.conf"
+
 pg_bin_path: "/usr/pgsql-{{ pg_major_version }}/bin"
 pg_default_data: "/var/lib/pgsql/{{ pg_major_version }}/data"
 

--- a/roles/manage_dbserver/vars/main.yml
+++ b/roles/manage_dbserver/vars/main.yml
@@ -14,7 +14,8 @@ psqlrc_group: "{{ pg_group }}"
 psqlrc_mode: "0600"
 psqlrc_content: |
   -- psql configuration
-
+  \set PROMPT1 '%n@%/:%>-%# '
+  \set PROMPT2 '%# '
 multi_param_list:
   - local_preload_libraries
   - session_preload_libraries

--- a/roles/manage_dbserver/vars/main.yml
+++ b/roles/manage_dbserver/vars/main.yml
@@ -14,8 +14,6 @@ psqlrc_group: "{{ pg_group }}"
 psqlrc_mode: "0600"
 psqlrc_content: |
   -- psql configuration
-  \set PROMPT1 '%n@%/:%>-%# '
-  \set PROMPT2 '%# '
 multi_param_list:
   - local_preload_libraries
   - session_preload_libraries

--- a/roles/setup_replication/README.md
+++ b/roles/setup_replication/README.md
@@ -32,6 +32,17 @@ Operating Systems supported are: CentOS7 and RHEL7
 
   Database Engine supported are: `PG`
 
+### `standby_quorum_type`
+
+Using this parameters user can set backend flag registered in pgpool-II.
+Users can set only "any" or "first".
+
+Example:
+
+```yaml
+standby_quorum_type: "any"
+```
+
 The rest of the variables can be configured and are available in the:
 
   * [roles/setup_replication/defaults/main.yml](./defaults/main.yml)

--- a/roles/setup_replication/defaults/main.yml
+++ b/roles/setup_replication/defaults/main.yml
@@ -10,6 +10,8 @@ pg_data: "{{ pg_user_home + '/' + pg_major_version + '/data' if ansible_os_famil
 # postgres user(os)
 pg_owner: "postgres"
 pg_group: "postgres"
+pg_owner_id: "{{ omit }}"
+pg_group_id: "{{ omit }}"
 
 pg_wal: ""
 pg_local_wal_archive_dir: ""
@@ -32,5 +34,7 @@ use_hostname: false
 
 update_etc_file: true
 etc_hosts_lists: []
+
+standby_quorum_type: "any"
 
 disable_logging: true

--- a/roles/setup_replication/tasks/create_directories.yml
+++ b/roles/setup_replication/tasks/create_directories.yml
@@ -23,6 +23,15 @@
     - initdb_cmd.changed
   become: true
 
+- name: Ensure User home directory's file privilege
+  ansible.builtin.file:
+    path: "{{ pg_user_home }}"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    state: directory
+    recurse: true
+  become: true
+
 - name: Ensure postgres default data directory exists
   ansible.builtin.file:
     path: "{{ pg_default_data }}"

--- a/roles/setup_replication/tasks/create_os_user.yml
+++ b/roles/setup_replication/tasks/create_os_user.yml
@@ -1,0 +1,13 @@
+---
+- name: Create {{ pg_group }} Group
+  ansible.builtin.group:
+    name: "{{ pg_group }}"
+    gid: "{{ pg_group_id | default(omit) }}"
+    state: present
+
+- name: Create {{ pg_owner }} User
+  ansible.builtin.user:
+    name: "{{ pg_owner }}"
+    uid: "{{ pg_owner_id | default(omit) }}"
+    group: "{{ pg_group }}"
+    home: "{{ pg_user_home }}"

--- a/roles/setup_replication/tasks/primary_synchronous_param.yml
+++ b/roles/setup_replication/tasks/primary_synchronous_param.yml
@@ -5,6 +5,11 @@
   when:
     - synchronous_standby_names|length < 1
 
+- name: Check Quorum type
+  fail:
+    msg: standby_quorum_type is not defined as 'any' or 'first'
+  when: standby_quorum_type not in ['any', 'first']
+
 - name: Add standby quorum string
   set_fact:
     synchronous_standby_names: "{{ standby_quorum_type + _synchronous_standby_names }}"

--- a/roles/setup_replication/tasks/setup_replication.yml
+++ b/roles/setup_replication/tasks/setup_replication.yml
@@ -92,6 +92,8 @@
 - name: Build standby service check
   become: true
   block:
+    - name: Import create_os_user task
+      ansible.builtin.import_tasks: create_os_user.yml
     - name: Create directories if not exists
       ansible.builtin.import_tasks: create_directories.yml
     - name: Take PG base backup

--- a/roles/setup_replication/vars/main.yml
+++ b/roles/setup_replication/vars/main.yml
@@ -22,7 +22,6 @@ use_replication_slots: true
 pg_database: "postgres"
 
 synchronous_standby_names: ""
-standby_quorum_type: "any"
 
 primary_private_ip: ""
 primary_public_ip: ""

--- a/roles/setup_repmgr/tasks/repmgr_setup_systemd.yml
+++ b/roles/setup_repmgr/tasks/repmgr_setup_systemd.yml
@@ -26,6 +26,16 @@
   become: true
   when: ansible_os_family == 'Debian'
 
+- name: Create repmgr socket domain directories
+  file:
+    path: "/var/run/repmgr"
+    owner: "{{ pg_owner }}"
+    group: "{{ pg_group }}"
+    mode: 0755
+    state: directory
+    recurse: yes
+  become: true
+
 - name: Enable and start repmgrd
   ansible.builtin.systemd:
     name: "{{ repmgrd_service }}"

--- a/tests/cases/init_dbserver/vars.json
+++ b/tests/cases/init_dbserver/vars.json
@@ -1,4 +1,5 @@
 {
+  "ansible_module_running_in_container": false,
   "pg_owner": "opensql",
   "pg_group": "opensql",
   "pg_port": 5433,

--- a/tests/cases/manage_dbserver/vars.json
+++ b/tests/cases/manage_dbserver/vars.json
@@ -1,4 +1,7 @@
 {
+  "ansible_module_running_in_container": false,
+  "pg_owner": "opensql",
+  "pg_group": "opensql",
   "use_hostname": false,
   "pg_data": "/opt/pgdata",
   "pg_wal": "/opt/pgwal",

--- a/tests/cases/setup_replication/vars.json
+++ b/tests/cases/setup_replication/vars.json
@@ -1,4 +1,8 @@
 {
+  "ansible_module_running_in_container": false,
+  "pg_owner": "opensql",
+  "pg_group": "opensql",
+  "standby_quorum_type": "first",
   "use_hostname": false,
   "pg_data": "/opt/pgdata",
   "pg_wal": "/opt/pgwal"

--- a/tests/cases/setup_repmgr/vars.json
+++ b/tests/cases/setup_repmgr/vars.json
@@ -1,4 +1,6 @@
 {
+  "pg_owner": "opensql",
+  "pg_group": "opensql",
   "use_hostname": false,
   "pg_data": "/var/lib/pgsql/14/main/data",
   "pg_wal": "/opt/pgwal",

--- a/tests/tests/test_manage_dbserver.py
+++ b/tests/tests/test_manage_dbserver.py
@@ -9,8 +9,8 @@ from conftest import (
 
 def test_manage_dbserver_files():
     ansible_vars = load_ansible_vars()
-    pg_user = "postgres"
-    pg_group = "postgres"
+    pg_user = ansible_vars["pg_owner"]
+    pg_group = ansible_vars["pg_group"]
     pg_profile_path = get_pg_profile_dir()
     pg_sql_script = ansible_vars["pg_sql_scripts"][0]["file_path"]
     profile_prefix = "pgsql"
@@ -67,7 +67,7 @@ def test_manage_dbserver_files():
 
 def test_manage_dbserver_create_user():
     ansible_vars = load_ansible_vars()
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
     pg_created_user = ansible_vars["pg_users"][0]["name"]
 
     host = get_primary()
@@ -82,7 +82,7 @@ def test_manage_dbserver_create_user():
 
 def test_manage_dbserver_sql_script():
     ansible_vars = load_ansible_vars()
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
     pg_sql_script = ansible_vars["pg_sql_scripts"][0]["file_path"]
     pg_script_table = ansible_vars["pg_script_table"]
 
@@ -101,7 +101,8 @@ def test_manage_dbserver_sql_script():
 
 
 def test_manage_dbserver_hba_file():
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -120,7 +121,7 @@ def test_manage_dbserver_hba_file():
 def test_manage_dbserver_conf_params():
     ansible_vars = load_ansible_vars()
     pg_conf_param = ansible_vars["pg_postgres_conf_params"][0]["name"]
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -137,7 +138,7 @@ def test_manage_dbserver_pg_slots():
     ansible_vars = load_ansible_vars()
     pg_slot = ansible_vars["pg_slots"][0]["name"]
 
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -154,7 +155,7 @@ def test_manage_dbserver_pg_extension():
     ansible_vars = load_ansible_vars()
     pg_extension = ansible_vars["pg_extensions"][0]["name"]
 
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -171,7 +172,7 @@ def test_manage_dbserver_pg_grant_roles():
     ansible_vars = load_ansible_vars()
     pg_role = ansible_vars["pg_grant_roles"][0]["role"]
 
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -194,7 +195,7 @@ def test_manage_dbserver_query():
     ansible_vars = load_ansible_vars()
     pg_query_table = ansible_vars["pg_query_table"]
 
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -211,7 +212,7 @@ def test_manage_dbserver_database():
     ansible_vars = load_ansible_vars()
     pg_database = ansible_vars["pg_databases"][0]["name"]
 
-    pg_user = "postgres"
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()

--- a/tests/tests/test_setup_replication.py
+++ b/tests/tests/test_setup_replication.py
@@ -1,8 +1,9 @@
-from conftest import get_pg_type, get_pg_unix_socket_dir, get_primary, get_standbys
+from conftest import get_pg_type, get_pg_unix_socket_dir, get_primary, get_standbys, load_ansible_vars
 
 
 def test_setup_replication_user():
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -16,7 +17,8 @@ def test_setup_replication_user():
 
 
 def test_setup_replication_slots():
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     socket_dir = get_pg_unix_socket_dir()
@@ -30,7 +32,8 @@ def test_setup_replication_slots():
 
 
 def test_setup_replication_stat_replication():
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     host = get_primary()
     rep_count = len(get_standbys())
@@ -45,7 +48,8 @@ def test_setup_replication_stat_replication():
 
 
 def test_setup_replication_stat_wal_receiver():
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     hosts = get_standbys()
     socket_dir = get_pg_unix_socket_dir()

--- a/tests/tests/test_setup_repmgr.py
+++ b/tests/tests/test_setup_repmgr.py
@@ -6,6 +6,7 @@ from conftest import (
     get_primary,
     get_standbys,
     get_witness,
+    load_ansible_vars,
     os_family,
 )
 
@@ -56,7 +57,8 @@ def test_setup_repmgr_packages_debian():
 
 
 def test_setup_repmgr_user():
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     hosts = [get_primary(), get_witness()[0], get_standbys()[0]]
     socket_dir = get_pg_unix_socket_dir()
@@ -74,7 +76,8 @@ def test_setup_repmgr_node_status_redhat():
     if os_family() != "RedHat":
         pytest.skip()
 
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
     pg_version = get_pg_version()
     hosts = [get_primary(), get_witness()[0], get_standbys()[0]]
 
@@ -93,7 +96,8 @@ def test_setup_repmgr_node_status_debian():
     if os_family() != "Debian":
         pytest.skip()
 
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     hosts = [get_primary(), get_witness()[0], get_standbys()[0]]
 
@@ -109,7 +113,8 @@ def test_setup_repmgr_node_check_redhat():
     if os_family() != "RedHat":
         pytest.skip()
 
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
     pg_version = get_pg_version()
     hosts = [get_primary(), get_witness()[0], get_standbys()[0]]
 
@@ -133,7 +138,8 @@ def test_setup_repmgr_node_check_debian():
     if os_family() != "Debian":
         pytest.skip()
 
-    pg_user = "postgres"
+    ansible_vars = load_ansible_vars()
+    pg_user = ansible_vars["pg_owner"]
 
     hosts = [get_primary(), get_witness()[0], get_standbys()[0]]
 


### PR DESCRIPTION
## Classification
- [ ] Feature
- [ ] Hotfix
- [X] Patch
- [ ] Others

## Content
- Changed the OS user and OS group that controls PostgreSQL in the overall role to be a user other than postgres
- Added init_dbserver paramters : `pg_owner`, `pg_group`, `pg_owner_id`, `pg_group_id`
- Add pg_profile so that the set OS user can use command alias
- Added `standby_quorum_type` parameter in PostgreSQL `synchronous_standby_names` paramter

## Reproduction Steps
- set pg_owner, pg_group init_dbserver
```yaml
set_fact:
   pg_owner: "want_to_set_user"
   pg_group: "want_to_set_group"
roles:
  - role: setup_repo
  - role: install_dbserver
  - role: init_dbserver
```