### PR TITLE
Fix ims-308804

### DIFF
--- a/roles/setup_pgpool2/templates/follow_primary.sh.template
+++ b/roles/setup_pgpool2/templates/follow_primary.sh.template
@@ -47,15 +47,32 @@ PGPASSFILE={{ pgpass_file }}
 SSH_KEY_FILE=id_rsa
 SSH_OPTIONS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/${SSH_KEY_FILE}"
 FAILOVER_LOG={{ pgpool2_logdir }}/failover.log
+CHECK_PG_READY_RETRY_COUNT=60
+CHECK_PG_READY_RETRY_INTERVAL=5
 
 echo follow_primary.sh: start: Standby node ${NODE_ID} >> ${FAILOVER_LOG}
 
 # Check the connection status of Standby
-${PGHOME}/bin/pg_isready -h ${NODE_HOST} -p ${NODE_PORT} > /dev/null 2>&1
+PG_ISREADY=0
+SET=$(seq 1 ${CHECK_PG_READY_RETRY_COUNT})
+for i in ${SET}
+do
+  echo follow_primary.sh: check pg_isready on node_id=${NODE_ID}, try_cnt=${i} >> ${FAILOVER_LOG}
+  ${PGHOME}/bin/pg_isready -h ${NODE_HOST} -p ${NODE_PORT} > /dev/null 2>&1
+  result=$?
+  if [[ $result == 0 ]] ; then
+    PG_ISREADY=1
+    break
+  else
+   sleep ${CHECK_PG_READY_RETRY_INTERVAL}
+  fi
+done
 
-if [ $? -ne 0 ]; then
+if [ $PG_ISREADY -ne 1 ]; then
     echo follow_primary.sh: node_id=${NODE_ID} is not running. skipping follow primary command >> ${FAILOVER_LOG}
     exit 0
+else
+    echo follow_primary.sh: node_id=${NODE_ID} is running. >> ${FAILOVER_LOG}
 fi
 
 # Test passwordless SSH

--- a/tests/scripts/test-runner.py
+++ b/tests/scripts/test-runner.py
@@ -431,7 +431,7 @@ def build_inventory(case_name, os_type, pg_version, hostnames):
     common.Logger().debug(dict_to_log_str("inventory_vars", inventory_vars))
     template_dir = os.path.join(common.ANSIBLE_TEST_HOME, f"cases/{case_name}")
     file_loader = FileSystemLoader(template_dir)
-    jenv = Environment(loader=file_loader, trim_blocks=True)
+    jenv = Environment(loader=file_loader, trim_blocks=True, autoescape=False)
     template = jenv.get_template("inventory.yml.j2")
 
     inventory_file_name = get_container_name_prefix(case_name, os_type, pg_version)
@@ -454,7 +454,7 @@ def build_add_hosts(case_name, os_type, pg_version, hostnames):
             container = DockerContainer(cid)
             f.write(f"ssh-keyscan -H {container.ip()} >> ~/.ssh/known_hosts\n")
 
-    os.chmod(add_hosts_script_path, 0o755)
+    os.chmod(add_hosts_script_path, 0o744)
 
 def get_ansible_tester_docker_ctnr_run_command(case_name, os_type, pg_version):
     ctnr_name = f"{get_container_name_prefix(case_name, os_type, pg_version)}_ansible_tester"


### PR DESCRIPTION
## Classification
- [ ] Feature
- [ ] Hotfix
- [x] Patch
- [ ] Others

## Content
- Added timeout in follow_primary.sh of pgpool-II
- Fixed github security reports in code scanning


## Reproduction Steps
- Before this commit, when a standby has been shutdown after doing failover, then follow_primary.sh just skips the node.
- After this commit, pgpool-II waits for 5 minutes for the standby to start up again.
