### PR TITLE
 Fixed bug that occurred after rhel9 compatibility

### DIFF
--- a/roles/init_dbserver/README.md
+++ b/roles/init_dbserver/README.md
@@ -214,7 +214,7 @@ Below is an example of how to include the `init_dbserver` role:
         pg_type: "PG"
 
   roles:
-    - initdb_dbserver
+    - init_dbserver
 ```
 
 Defining and adding variables is done in the `set_fact` of the `pre_tasks`.

--- a/roles/init_dbserver/tasks/ensure_postgresql_process.yml
+++ b/roles/init_dbserver/tasks/ensure_postgresql_process.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if it have postgres pid exists or not
+  ansible.builtin.stat:
+    path: "{{ pg_default_data }}/postmaster.pid"
+  become: true
+  register: postgres_pid_file
+
+- name: Fetch PostgreSQL pid
+  shell: |
+    set -o pipefail && cat {{ pg_default_data }}/postmaster.pid  | head -1
+  become: true
+  register: postgres_pid
+  changed_when: postgres_pid|length > 0
+  when: postgres_pid_file.stat.exists
+
+- name: Check PostgreSQL process is running
+  ansible.builtin.shell: >
+    ps -p {{ postgres_pid.stdout }}
+  become: true
+  register: _postgresql_exists
+  failed_when: false
+  when: postgres_pid_file.stat.exists
+

--- a/roles/init_dbserver/tasks/pg_initdb.yml
+++ b/roles/init_dbserver/tasks/pg_initdb.yml
@@ -46,9 +46,17 @@
   when: use_system_user
   become: true
 
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
+
 - name: Start pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} start
-  when: not use_system_user
+  when:
+    - not use_system_user
+    - _postgresql_exists.rc is not defined or _postgresql_exists.rc != 0
   become: true
   become_user: "{{ pg_owner }}"

--- a/roles/init_dbserver/tasks/pg_setup_systemd.yml
+++ b/roles/init_dbserver/tasks/pg_setup_systemd.yml
@@ -13,18 +13,18 @@
     - use_system_user
   become: true
 
-- name: Check if we have postgres pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pg_default_data }}/postmaster.pid"
-  become: true
-  register: postgres_pid_file
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
 
 - name: Stop pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
-    - postgres_pid_file.stat.exists
+    - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"
 

--- a/roles/init_dbserver/tasks/pg_setup_systemd.yml
+++ b/roles/init_dbserver/tasks/pg_setup_systemd.yml
@@ -24,6 +24,7 @@
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
+    - _postgresql_exists.rc is defined
     - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"

--- a/roles/init_dbserver/tasks/rm_initdb.yml
+++ b/roles/init_dbserver/tasks/rm_initdb.yml
@@ -13,18 +13,18 @@
     - user_system_user
   become: true
 
-- name: Check if we have postgres pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pg_default_data }}/postmaster.pid"
-  become: true
-  register: postgres_pid_file
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
 
 - name: Stop pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
-    - postgres_pid_file.stat.exists
+    - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"
 

--- a/roles/init_dbserver/tasks/rm_initdb.yml
+++ b/roles/init_dbserver/tasks/rm_initdb.yml
@@ -24,6 +24,7 @@
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
+    - _postgresql_exists.rc is defined
     - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"

--- a/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
@@ -18,18 +18,18 @@
     - use_system_user
   become: true
 
-- name: Check if we have postgres pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pg_default_data }}/postmaster.pid"
-  become: true
-  register: postgres_pid_file
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
 
 - name: Stop pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
-    - postgres_pid_file.stat.exists
+    - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"
 

--- a/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_Debian_rm_install.yml
@@ -29,6 +29,7 @@
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
+    - _postgresql_exists.rc is defined
     - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"

--- a/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
@@ -18,18 +18,18 @@
     - use_system_user
   become: true
 
-- name: Check if we have postgres pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pg_default_data }}/postmaster.pid"
-  become: true
-  register: postgres_pid_file
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
 
 - name: Stop pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
-    - postgres_pid_file.stat.exists
+    - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"
 

--- a/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
+++ b/roles/install_dbserver/tasks/PG_RedHat_rm_install.yml
@@ -29,6 +29,7 @@
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
+    - _postgresql_exists.rc is defined
     - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"

--- a/roles/install_dbserver/tasks/ensure_postgresql_process.yml
+++ b/roles/install_dbserver/tasks/ensure_postgresql_process.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if it have postgres pid exists or not
+  ansible.builtin.stat:
+    path: "{{ pg_default_data }}/postmaster.pid"
+  become: true
+  register: postgres_pid_file
+
+- name: Fetch PostgreSQL pid
+  shell: |
+    set -o pipefail && cat {{ pg_default_data }}/postmaster.pid  | head -1
+  become: true
+  register: postgres_pid
+  changed_when: postgres_pid|length > 0
+  when: postgres_pid_file.stat.exists
+
+- name: Check PostgreSQL process is running
+  ansible.builtin.shell: >
+    ps -p {{ postgres_pid.stdout }}
+  become: true
+  register: _postgresql_exists
+  failed_when: false
+  when: postgres_pid_file.stat.exists
+

--- a/roles/manage_barmanbackup/tasks/configure_pg_backup.yml
+++ b/roles/manage_barmanbackup/tasks/configure_pg_backup.yml
@@ -44,7 +44,7 @@
     name: manage_dbserver
     tasks_from: manage_slots
   vars:
-    pg_slots:
+    input_pg_slots:
       - name: barman_{{ inventory_hostname }}_{{ pg_instance_name }}
         slot_type: physical
   no_log: "{{ disable_logging }}"

--- a/roles/manage_dbserver/tasks/manage_hba_conf.yml
+++ b/roles/manage_dbserver/tasks/manage_hba_conf.yml
@@ -46,6 +46,7 @@
     set -o pipefail && cat {{ pg_default_data }}/postmaster.pid  | head -1
   register: postgres_pid
   changed_when: postgres_pid|length > 0
+  when: postgres_pid_file.stat.exists
 
 - name: Reload the pg process
   ansible.builtin.command: >

--- a/roles/manage_dbserver/tasks/manage_postgres_params.yml
+++ b/roles/manage_dbserver/tasks/manage_postgres_params.yml
@@ -42,6 +42,7 @@
     set -o pipefail && cat {{ pg_default_data }}/postmaster.pid  | head -1
   register: postgres_pid
   changed_when: postgres_pid|length > 0
+  when: postgres_pid_file.stat.exists
 
 - name: Reload the pg process
   ansible.builtin.command: >
@@ -51,6 +52,7 @@
     - params.changed
     - params_restart_required is defined
     - not params_restart_required
+    - postgres_pid_file.stat.exists
   become: true
   become_user: "{{ pg_owner }}"
 

--- a/roles/manage_pgpool2/tasks/ensure_pgpool2_process.yml
+++ b/roles/manage_pgpool2/tasks/ensure_pgpool2_process.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if it have pgpool-II pid exists or not
+  ansible.builtin.stat:
+    path: "{{ pgpool2_pid_file_name }}"
+  become: true
+  register: pgpool2_pid_file
+
+- name: Fetch pgpool-II pid
+  shell: |
+    set -o pipefail && cat {{ pgpool2_pid_file_name }}  | head -1
+  become: true
+  register: pgpool2_pid
+  changed_when: pgpool2_pid|length > 0
+  when: pgpool2_pid_file.stat.exists
+
+- name: Check pgpool-II process is running
+  ansible.builtin.shell: >
+    ps -p {{ pgpool2_pid.stdout }}
+  become: true
+  register: _pgpool2_exists
+  failed_when: false
+  when: pgpool2_pid_file.stat.exists
+

--- a/roles/manage_pgpool2/tasks/pgpool2_restart.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_restart.yml
@@ -5,14 +5,16 @@
     state: restarted
   when: use_system_user
 
-- name: Check if we have pgpoolII pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pgpool2_pid_file_name }}"
-  become: true
-  register: pgpool2_pid_file_exists
+- name: Include ensure_pgpool2_process.yml tasks
+  include_tasks: ensure_pgpool2_process.yml
+  vars:
+    - _pgpool2_exists: ""
+  when: not use_system_user
 
 - name: Restart pgpool-II process
-  when: not use_system_user
+  when:
+    - not use_system_user
+    - _pgpool2_exists.rc == 0
   become: true
   become_user: "{{ pgpool2_user }}"
   block:

--- a/roles/manage_pgpool2/tasks/pgpool2_restart.yml
+++ b/roles/manage_pgpool2/tasks/pgpool2_restart.yml
@@ -14,6 +14,7 @@
 - name: Restart pgpool-II process
   when:
     - not use_system_user
+    - _pgpool2_exists.rc is defined
     - _pgpool2_exists.rc == 0
   become: true
   become_user: "{{ pgpool2_user }}"

--- a/roles/setup_pgpool2/tasks/ensure_pgpool2_process.yml
+++ b/roles/setup_pgpool2/tasks/ensure_pgpool2_process.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if it have pgpool-II pid exists or not
+  ansible.builtin.stat:
+    path: "{{ pgpool2_pid_file_name }}"
+  become: true
+  register: pgpool2_pid_file
+
+- name: Fetch pgpool-II pid
+  shell: |
+    set -o pipefail && cat {{ pgpool2_pid_file_name }}  | head -1
+  become: true
+  register: pgpool2_pid
+  changed_when: pgpool2_pid|length > 0
+  when: pgpool2_pid_file.stat.exists
+
+- name: Check pgpool-II process is running
+  ansible.builtin.shell: >
+    ps -p {{ pgpool2_pid.stdout }}
+  become: true
+  register: _pgpool2_exists
+  failed_when: false
+  when: pgpool2_pid_file.stat.exists
+

--- a/roles/setup_pgpool2/tasks/exchange_ssh_keys.yml
+++ b/roles/setup_pgpool2/tasks/exchange_ssh_keys.yml
@@ -22,6 +22,7 @@
   loop: "{{ _pg_cluster_nodes }}"
   loop_control:
     loop_var: server
+  throttle: 1
 
 - name: Run ssh-keyscan and Add known hosts
   include_tasks: add_known_hosts.yml

--- a/roles/setup_pgpool2/tasks/pgpool2_restart.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_restart.yml
@@ -7,14 +7,16 @@
   when: use_system_user
   become: true
 
-- name: Check if we have pgpoolII pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pgpool2_pid_file_name }}"
-  become: true
-  register: pgpool2_pid_file_exists
+- name: Include ensure_pgpool2_process.yml tasks
+  include_tasks: ensure_pgpool2_process.yml
+  vars:
+    - _pgpool2_exists: ""
+  when: not use_system_user
 
 - name: Restart pgpool-II process
-  when: not use_system_user
+  when:
+    - not use_system_user
+    - _pgpool2_exists.rc == 0
   become: true
   become_user: "{{ pgpool2_user }}"
   block:

--- a/roles/setup_pgpool2/tasks/pgpool2_restart.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_restart.yml
@@ -16,6 +16,7 @@
 - name: Restart pgpool-II process
   when:
     - not use_system_user
+    - _pgpool2_exists.rc is defined
     - _pgpool2_exists.rc == 0
   become: true
   become_user: "{{ pgpool2_user }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -168,6 +168,7 @@
   command: "{{ pgpool_stop_command }}"
   when:
     - not use_system_user
+    - _pgpool2_exists.rc is defined
     - _pgpool2_exists.rc == 0
   become: true
   become_user: "{{ pgpool2_user }}"

--- a/roles/setup_pgpool2/tasks/pgpool2_setup.yml
+++ b/roles/setup_pgpool2/tasks/pgpool2_setup.yml
@@ -158,17 +158,17 @@
   when: use_system_user
   become: true
 
-- name: Check if we have pgpoolII pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pgpool2_pid_file_name }}"
-  become: true
-  register: pgpool2_pid_file_exists
+- name: Include ensure_pgpool2_process.yml tasks
+  include_tasks: ensure_pgpool2_process.yml
+  vars:
+    - _pgpool2_exists: ""
+  when: not use_system_user
 
 - name: Stop pgpool-II process
   command: "{{ pgpool_stop_command }}"
   when:
     - not use_system_user
-    - pgpool2_pid_file_exists.stat.exists
+    - _pgpool2_exists.rc == 0
   become: true
   become_user: "{{ pgpool2_user }}"
 

--- a/roles/setup_replication/tasks/configure_node.yml
+++ b/roles/setup_replication/tasks/configure_node.yml
@@ -46,11 +46,18 @@
   when: use_system_user
   become: true
 
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
+
 - name: Start pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} start
   when:
     - not use_system_user
+    - _postgresql_exists.rc is not defined or _postgresql_exists.rc != 0
   become: true
   become_user: "{{ pg_owner }}"
 

--- a/roles/setup_replication/tasks/ensure_postgresql_process.yml
+++ b/roles/setup_replication/tasks/ensure_postgresql_process.yml
@@ -1,0 +1,23 @@
+---
+- name: Check if it have postgres pid exists or not
+  ansible.builtin.stat:
+    path: "{{ pg_default_data }}/postmaster.pid"
+  become: true
+  register: postgres_pid_file
+
+- name: Fetch PostgreSQL pid
+  shell: |
+    set -o pipefail && cat {{ pg_default_data }}/postmaster.pid  | head -1
+  become: true
+  register: postgres_pid
+  changed_when: postgres_pid|length > 0
+  when: postgres_pid_file.stat.exists
+
+- name: Check PostgreSQL process is running
+  ansible.builtin.shell: >
+    ps -p {{ postgres_pid.stdout }}
+  become: true
+  register: _postgresql_exists
+  failed_when: false
+  when: postgres_pid_file.stat.exists
+

--- a/roles/setup_replication/tasks/pg_setup_systemd.yml
+++ b/roles/setup_replication/tasks/pg_setup_systemd.yml
@@ -13,18 +13,18 @@
     - use_system_user
   become: true
 
-- name: Check if we have postgres pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pg_default_data }}/postmaster.pid"
-  become: true
-  register: postgres_pid_file
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
 
 - name: Stop pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
-    - postgres_pid_file.stat.exists
+    - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"
 

--- a/roles/setup_replication/tasks/pg_setup_systemd.yml
+++ b/roles/setup_replication/tasks/pg_setup_systemd.yml
@@ -24,6 +24,7 @@
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
+    - _postgresql_exists.rc is defined
     - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"

--- a/roles/setup_replication/tasks/rm_replication.yml
+++ b/roles/setup_replication/tasks/rm_replication.yml
@@ -23,6 +23,7 @@
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
+    - _postgresql_exists.rc is defined
     - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"

--- a/roles/setup_replication/tasks/rm_replication.yml
+++ b/roles/setup_replication/tasks/rm_replication.yml
@@ -12,18 +12,18 @@
     - use_system_user
   become: true
 
-- name: Check if we have postgres pid exists or not
-  ansible.builtin.stat:
-    path: "{{ pg_default_data }}/postmaster.pid"
-  become: true
-  register: postgres_pid_file
+- name: Include ensure_postgresql_process.yml tasks
+  include_tasks: ensure_postgresql_process.yml
+  vars:
+    - _postgresql_exists: ""
+  when: not use_system_user
 
 - name: Stop pg process
   ansible.builtin.command: >
     {{ pg_bin_path }}/pg_ctl -D {{ pg_default_data }} stop
   when:
     - not use_system_user
-    - postgres_pid_file.stat.exists
+    - _postgresql_exists.rc == 0
   become: true
   become_user: "{{ pg_owner }}"
 


### PR DESCRIPTION
## Classification
- [ ] Feature
- [ ] Hotfix
- [X] Patch
- [ ] Others

## Content
- Changed checking the PID file at the `start` and `stop` of the postgresql process and at the `stop` of pgpool-II to checking the pid number of the PID file to check whether the process is actually running.
- Modified managing postgreSQL slot bug.
## Reproduction Steps
- pg_slot test
  1. Setting the variables of pg_slot
  2. Run manage_dbserver.
- PID test
  1. Create postmaster.pid
  2. Run init_dbserver