### PR TITLE
Fixed typo in init_dbserver/rm_initdb

### DIFF
--- a/roles/init_dbserver/tasks/rm_initdb.yml
+++ b/roles/init_dbserver/tasks/rm_initdb.yml
@@ -10,7 +10,7 @@
   when:
     - ansible_facts.services[pg_service] is defined
     - ansible_facts.services[pg_service].state == 'running'
-    - user_system_user
+    - use_system_user
   become: true
 
 - name: Include ensure_postgresql_process.yml tasks


### PR DESCRIPTION
## Classification
- [ ] Feature
- [x] Hotfix
- [ ] Patch
- [ ] Others

## Content
Suppresses #64 with better branch name

- There's a typo in init_dbserver role, rm_initdb.yml file, that leads to the following error if playbook goes through this task:
```
fatal: [pg1]: FAILED! => {"msg": "The conditional check 'user_system_user' failed. The error was: error while evaluating conditional (user_system_user): 'user_system_user' is undefined. 'user_system_user' is undefined\n\nThe error appears to be in '/root/.ansible/collections/ansible_collections/tmax_opensql/postgres/roles/init_dbserver/tasks/rm_initdb.yml': line 5, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Stop pg service if running\n  ^ here\n"}
```

## Reproduction Steps
- run playbook with `force_initdb: true` so it will include the file with typo.
